### PR TITLE
Use all_linters() with tweaks

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,24 +1,11 @@
-linters: linters_with_defaults(
-    any_duplicated_linter(),
-    any_is_na_linter(),
-    consecutive_assertion_linter(),
-    expect_comparison_linter(),
-    expect_length_linter(),
-    expect_named_linter(),
-    expect_not_linter(),
-    expect_null_linter(),
-    expect_s3_class_linter(),
-    expect_s4_class_linter(),
-    expect_true_false_linter(),
-    expect_type_linter(),
-    implicit_integer_linter(),
-    line_length_linter(80),
-    missing_argument_linter(),
-    nested_ifelse_linter(),
-    numeric_leading_zero_linter(),
-    paste_linter(),
-    redundant_ifelse_linter(),
-    sprintf_linter(),
-    unnecessary_concatenation_linter(allow_single_expression = FALSE),
-    yoda_test_linter()
+linters: all_linters(
+    implicit_integer_linter = implicit_integer_linter(allow_colon=TRUE),
+    todo_comment_linter(except_regex = rex::rex("TODO(#", one_or_more(digit), ")")),
+    cyclocomp_linter = NULL
+  )
+exclusions: list(
+    "tests/testthat.R" = list(
+      undesirable_function_linter = Inf,
+      unused_import_linter = Inf
+    )
   )

--- a/R/with_parameters.R
+++ b/R/with_parameters.R
@@ -124,7 +124,7 @@ with_parameters_test_that <- function(desc_stub,
   } else {
     all_pars <- .cases
   }
-  # TODO: drop this once downstream users upgrade their version of patrick.
+  # TODO(#33): deprecate & remove this branch
   if ("test_name" %in% names(all_pars)) {
     msg <- paste(
       'The argument and cases column "test_name" is deprecated. Please use the',
@@ -166,8 +166,8 @@ build_test_names <- function(all_cases) {
 }
 
 build_label <- function(..., case_names) {
-  row <- format(list(...))
-  toString(sprintf("%s=%s", case_names, row))
+  case_row <- format(list(...))
+  toString(sprintf("%s=%s", case_names, case_row))
 }
 
 build_description <- function(args, desc, .test_name, .interpret_glue) {
@@ -176,8 +176,10 @@ build_description <- function(args, desc, .test_name, .interpret_glue) {
     if (inherits(completed_desc, "error")) {
       abort(sprintf(
         paste(
-          "Attempt to interpret test stub '%s' with glue failed with error:\n%s\n\n",
-          "Set .interpret_glue=FALSE if this test name does not use glue."
+          "Attempt to interpret test stub '%s' with glue failed with error:",
+          "%s", "",
+          "Set .interpret_glue=FALSE if this test name does not use glue.",
+          sep = "\n"
         ),
         # indent for clarity (the purrr error has similar mark-up)
         desc, gsub("(^|\n)", "\\1  ", conditionMessage(completed_desc))
@@ -200,12 +202,15 @@ build_description <- function(args, desc, .test_name, .interpret_glue) {
   completed_desc
 }
 
-build_and_run_test <- function(..., .test_name, desc, code, env, .interpret_glue) {
-  args <- list(..., .test_name = .test_name)
-  completed_desc <- build_description(args, desc, .test_name, .interpret_glue)
+build_and_run_test <- function(
+  ..., .test_name, desc, code, env, .interpret_glue
+) {
+  test_args <- list(..., .test_name = .test_name)
+  completed_desc <-
+    build_description(test_args, desc, .test_name, .interpret_glue)
 
   withCallingHandlers(
-    test_that(completed_desc, eval_tidy(code, args)),
+    test_that(completed_desc, eval_tidy(code, test_args)),
     testthat_braces_warning = cnd_muffle
   )
 }

--- a/tests/testthat/test-with_parameters.R
+++ b/tests/testthat/test-with_parameters.R
@@ -45,7 +45,7 @@ with_parameters_test_that(
   },
   .cases = data.frame(
     logical = FALSE,
-    number = 1,
+    number = 1.0,
     string = "hello",
     stringsAsFactors = FALSE
   )
@@ -57,8 +57,8 @@ with_parameters_test_that(
     testthat::expect_length(vec, len)
   },
   cases(
-    one = list(vec = 1, len = 1),
-    ten = list(vec = 1:10, len = 10)
+    one = list(vec = 1L, len = 1L),
+    ten = list(vec = 1:10, len = 10L)
   )
 )
 
@@ -67,19 +67,19 @@ with_parameters_test_that(
   {
     testthat::expect_identical(.test_name, "vec=1, len=1")
   },
-  cases(list(vec = 1, len = 1))
+  cases(list(vec = 1L, len = 1L))
 )
 
 with_parameters_test_that(
   "Data frames can be passed to cases:",
   {
     result <- rlang::as_function(FUN)(input)
-    testthat::expect_equal(result, out)
+    testthat::expect_identical(result, out)
   },
   .cases = tibble::tribble(
     ~.test_name, ~FUN, ~input, ~out,
-    "times", ~ .x * 2, 2, 4,
-    "plus", ~ .x + 3, 3, 6
+    "times", ~ .x * 2L, 2L, 4L,
+    "plus", ~ .x + 3L, 3L, 6L
   )
 )
 
@@ -89,9 +89,9 @@ with_parameters_test_that(
     testthat::expect_warning(fun(), regexp = message)
   },
   cases(
-    shouldnt_warn = list(fun = function() 1 + 1, message = NA),
+    shouldnt_warn = list(fun = function() 1L + 1L, message = NA),
     should_warn = list(
-      fun = function() warning("still warn!"),
+      fun = function() warning("still warn!", call. = FALSE),
       message = "still warn"
     )
   )
@@ -118,16 +118,17 @@ test_that("Patrick catches the right class of warning", {
 # From testthat/tests/testthat/test-test-that.R
 # Use for checking that line numbers are still correct
 expectation_lines <- function(code) {
-  srcref <- attr(substitute(code), "srcref")
-  if (!is.list(srcref)) {
+  code_srcref <- attr(substitute(code), "srcref")
+  if (!is.list(code_srcref)) {
     stop("code doesn't have srcref", call. = FALSE)
   }
 
   results <- testthat::with_reporter("silent", code)$expectations()
-  unlist(lapply(results, function(x) x$srcref[1])) - srcref[[1]][1]
+  unlist(lapply(results, function(x) x$srcref[1L])) - code_srcref[[1L]][1L]
 }
 
 test_that("patrick reports the correct line numbers", {
+  # nolint start: indentation_linter.
   lines <- expectation_lines({
                                                  # line 1
     with_parameters_test_that("simple", {        # line 2
@@ -138,7 +139,8 @@ test_that("patrick reports the correct line numbers", {
       false = list(truth = FALSE)
     ))
   })
-  expect_equal(lines, c(3, 3))
+  # nolint end: indentation_linter.
+  expect_identical(lines, c(3L, 3L))
 })
 
 test_that('patrick gives a deprecation warning for "test_name"', {
@@ -179,7 +181,7 @@ test_that("glue-formatted descriptions and test names supported", {
     expectation_names(with_parameters_test_that(
       "testing for (x, y, z) = ({x}, {y}, {z})",
       {
-        testthat::expect_true(x + y + z > 0)
+        testthat::expect_gt(x + y + z, 0L)
       },
       x = 1:10, y = 2:11, z = 3:12
     )),
@@ -190,7 +192,7 @@ test_that("glue-formatted descriptions and test names supported", {
     expectation_names(with_parameters_test_that(
       "testing for (x, y, z):",
       {
-        testthat::expect_true(x + y + z > 0)
+        testthat::expect_gt(x + y + z, 0L)
       },
       x = 1:10, y = 2:11, z = 3:12,
       .test_name = "({x}, {y}, {z})"
@@ -204,7 +206,7 @@ test_that("glue-formatted descriptions and test names supported", {
         expectation_names(with_parameters_test_that(
           "testing for (x, y): ({x}, {y})",
           {
-            testthat::expect_equal(x, y)
+            testthat::expect_identical(x, y)
           },
           x = list(NULL, 1:10), y = list(NULL, 1:10)
         )),
@@ -223,7 +225,7 @@ test_that("glue-formatted descriptions and test names supported", {
   expect_error(
     with_parameters_test_that("a{b}", {
       expect_true(TRUE)
-    }, .cases = data.frame(d = 1)),
+    }, .cases = data.frame(d = 1L)),
     "Attempt to interpret test stub 'a{b}' with glue failed",
     fixed = TRUE
   )
@@ -231,6 +233,6 @@ test_that("glue-formatted descriptions and test names supported", {
   expect_no_error(
     with_parameters_test_that("a{b}", {
       expect_true(TRUE)
-    }, .cases = data.frame(d = 1), .interpret_glue = FALSE)
+    }, .cases = data.frame(d = 1L), .interpret_glue = FALSE)
   )
 })


### PR DESCRIPTION
This gets closer to internal coding standard. Omit `cyclocomp_linter()` so we don't have to fiddle with installing it.