### PR TITLE
Require 4.1.0 and use its features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tests/testthat/testthat-problems.rds
+
+*.Rcheck
+*.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: This is an extension of the 'testthat' package that
 License: Apache License 2.0
 URL: https://github.com/google/patrick
 BugReports: https://github.com/google/patrick/issues
-Depends: R (>= 3.1)
+Depends: R (>= 4.1.0)
 Imports: dplyr, glue, purrr, rlang, testthat (>= 3.1.5), tibble
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 *  @chiricom is now the maintainer of {patrick}. Thanks @michaelquinn32
    for 7 years at the help as package creator and maintainer!
 *  Minor fix in the test suite to adapt to {testthat} 3.3.0. Thanks @hadley!
+*  Require R >= 4.1.0, which {testthat} 3.3.0 does as well.
 
 # patrick (0.3.0)
 

--- a/tests/testthat/test-with_parameters.R
+++ b/tests/testthat/test-with_parameters.R
@@ -211,7 +211,6 @@ test_that("glue-formatted descriptions and test names supported", {
     )) |>
     expect_warning("produced output of length 0")
     expect_warning("produced output of length 10")
-  )
 
   # but fail kindly for potential accidental use of glue
   #   c.f. https://github.com/r-lib/lintr/issues/2706


### PR DESCRIPTION
Since {testthat} now does so too