### PR TITLE
Require testthat 3.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ License: Apache License 2.0
 URL: https://github.com/google/patrick
 BugReports: https://github.com/google/patrick/issues
 Depends: R (>= 4.1.0)
-Imports: dplyr, glue, purrr, rlang, testthat (>= 3.1.5), tibble
+Imports: dplyr, glue, purrr, rlang, testthat (>= 3.2.0), tibble
 Config/testthat/edition: 3
 Encoding: UTF-8
 RoxygenNote: 7.3.2

--- a/tests/testthat/test-with_parameters.R
+++ b/tests/testthat/test-with_parameters.R
@@ -111,7 +111,7 @@ test_that("Patrick catches the right class of warning", {
     },
     truth = TRUE
   ) |>
-    testthat::expect_warning(regexp = NA)
+    testthat::expect_no_warning()
 })
 
 # From testthat/tests/testthat/test-test-that.R


### PR DESCRIPTION
For `expect_no_warning()`. It's 2 years old.