### PR TITLE
Re-roxygenize under 7.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports: dplyr, glue, purrr, rlang, testthat (>= 3.2.0), tibble
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 NeedsCompilation: no
 Packaged: 2020-10-27 18:23:21 UTC; msquinn
 Repository: CRAN

--- a/man/patrick-package.Rd
+++ b/man/patrick-package.Rd
@@ -6,17 +6,17 @@
 \alias{patrick-package}
 \title{Parameterized Unit Testing}
 \description{
-`patrick` (parameterized testing in R is kind of cool!) is a `testthat`
+\code{patrick} (parameterized testing in R is kind of cool!) is a \code{testthat}
 extension that lets you create reusable blocks of a test codes. Parameterized
 tests are often easier to read and more reliable, since they follow the DNRY
 (do not repeat yourself) rule. To do this, define tests with the function
-[with_parameters_test_that()]. Multiple approaches are provided for passing
+\code{\link[=with_parameters_test_that]{with_parameters_test_that()}}. Multiple approaches are provided for passing
 sets of cases.
 }
 \details{
 This package is inspired by parameterized testing packages in other
 languages, notably the
-[`parameterized`](https://github.com/wolever/parameterized) library in
+\href{https://github.com/wolever/parameterized}{\code{parameterized}} library in
 Python.
 }
 \examples{
@@ -84,11 +84,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Michael Quinn \email{msquinn@google.com}
+\strong{Maintainer}: Michael Chirico \email{chiricom@google.com}
 
-Other contributors:
+Authors:
 \itemize{
-  \item Michael Chirico \email{chiricom@google.com} [contributor]
+  \item Michael Quinn \email{michael.quinn@aya.yale.edu}
 }
 
 }

--- a/man/with_parameters_test_that.Rd
+++ b/man/with_parameters_test_that.Rd
@@ -28,15 +28,15 @@ same length.}
 \item{.cases}{A data frame where each row contains test parameters.}
 
 \item{.test_name}{An alternative way for providing test names. If provided,
-the name will be appended to the stub description in `desc_stub`. If not
+the name will be appended to the stub description in \code{desc_stub}. If not
 provided, test names will be automatically generated.}
 
-\item{.interpret_glue}{Logical, default `TRUE`. If `FALSE`, and glue-like
-markup in `desc_stub` is ignored, otherwise [glue::glue_data()] is
+\item{.interpret_glue}{Logical, default \code{TRUE}. If \code{FALSE}, and glue-like
+markup in \code{desc_stub} is ignored, otherwise \code{\link[glue:glue]{glue::glue_data()}} is
 attempted to produce a more complete test description.}
 }
 \description{
-This function is an extension of [testthat::test_that()] that lets you pass
+This function is an extension of \code{\link[testthat:test_that]{testthat::test_that()}} that lets you pass
 a series of testing parameters. These values are substituted into your
 regular testing code block, making it reusable and reducing duplication.
 }
@@ -44,21 +44,21 @@ regular testing code block, making it reusable and reducing duplication.
 You have a couple of options for passing parameters to you test. You can
 use named vectors/ lists. The function will assert that you have correct
 lengths before proceeding to test execution. Alternatively you can used
-a `data.frame` or list in combination with the splice unquote operator
-\code{\link[rlang]{!!!}}. Last, you can use the constructor `cases()`, which
-is similar to building a `data.frame` rowwise. If you manually build the
-data frame, pass it in the `.cases` argument.
+a \code{data.frame} or list in combination with the splice unquote operator
+\code{\link[rlang]{!!!}}. Last, you can use the constructor \code{cases()}, which
+is similar to building a \code{data.frame} rowwise. If you manually build the
+data frame, pass it in the \code{.cases} argument.
+\subsection{Naming test cases}{
 
-## Naming test cases
-
-If the user passes a character vector as `.test_name`, each instance is
-combined with `desc_stub` to create the completed test name. Similarly, the
-named argument from `cases()` is combined with `desc_stub` to create the
+If the user passes a character vector as \code{.test_name}, each instance is
+combined with \code{desc_stub} to create the completed test name. Similarly, the
+named argument from \code{cases()} is combined with \code{desc_stub} to create the
 parameterized test names. When names aren't provided, they will be
 automatically generated using the test data.
 
 Names follow the pattern of "name=value, name=value" for all elements in a
 test case.
+}
 }
 \examples{
 with_parameters_test_that("trigonometric functions match identities:",


### PR DESCRIPTION
Hm, seems it was a mistake to omit this step before CRAN submission as the patrick-package.Rd still has some outdated info...

This also should have been done in the #38 branch as it partially reflects markup being recognized as markdown. Alas.